### PR TITLE
set Rserve to use default 6311 port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN chmod 755 ${RSERVE_HOME}/bin/run_rserve.sh
 
 RUN mkdir ${RSERVE_HOME}/work
 
-EXPOSE 8080
+EXPOSE 6311
 
 CMD ["/opt/rserve/bin/run_rserve.sh"]

--- a/etc/Rserv.conf
+++ b/etc/Rserv.conf
@@ -5,5 +5,4 @@ remote enable
 fileio enable
 maxinbuf 500000
 plaintext disable
-port 8080
 encoding utf8


### PR DESCRIPTION
Rserve defaults to 6311, the principle of least surprise would indicate the default port.  If you want a different mapping, it can be done when running docker (e.g. `-p 8080:6311`) 