### PR TITLE
Fix/2/add mbio packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,22 @@ RUN useradd rserve \
 ## install libs
 RUN R -e "install.packages('Rserve', version='1.8-7', repos='http://rforge.net')"
 RUN R -e "install.packages('data.table')"
+RUN R -e "install.packages('ape')"
+RUN R -e "install.packages('vegan')"
+RUN R -e "install.packages('phytools')"
+RUN R -e "install.packages('rbiom')"
 RUN R -e "install.packages('bit64')"
 RUN R -e "install.packages('jsonlite')"
 RUN R -e "install.packages('remotes')"
 RUN R -e "remotes::install_github('VEuPathDB/plot.data','v0.5.3')"
+
+
+RUN apt-get update && apt-get install -y \
+	libglpk-dev \
+	libxml2-dev
+
+RUN R -e "install.packages('BiocManager')"
+RUN R -e "BiocManager::install('DESeq2')"
 
 
 ## Rserve

--- a/lib/preload.R
+++ b/lib/preload.R
@@ -1,3 +1,8 @@
 library(plot.data)
 library(data.table)
+library(ape)
+library(vegan)
+library(phytools)
+library(rbiom)
+library(DESeq2)
 source('/opt/rserve/lib/functions.R')


### PR DESCRIPTION
Fix for issue #2 

Added the following packages:
- ape
- vegan
- rbiom
- DESeq2
- phytools

These packages cover expected needs for phase 1 of each app in the EDA.

Tested by connecting to a running RServe and using a collection of relevant functions from each package.