### PR TITLE
upgrade packages for handling naToZero

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ RUN R -e "install.packages('jsonlite')"
 RUN R -e "install.packages('remotes')"
 RUN R -e "install.packages('Rcpp')"
 
-RUN R -e "remotes::install_github('VEuPathDB/veupathUtils', 'v1.0.0')"
-RUN R -e "remotes::install_github('VEuPathDB/plot.data','v1.4.13')"
-RUN R -e "remotes::install_github('VEuPathDB/microbiomeComputations', 'v1.0.0')"
+RUN R -e "remotes::install_github('VEuPathDB/veupathUtils', 'v1.0.1')"
+RUN R -e "remotes::install_github('VEuPathDB/plot.data','v1.5.0')"
+RUN R -e "remotes::install_github('VEuPathDB/microbiomeComputations', 'v1.0.2')"
 
 ## Rserve
 RUN mkdir -p /opt/rserve


### PR DESCRIPTION
This PR updates the three veupathdb R packages to versions that handle arguments and functions necessary for imputing zeros. 

**Testing**
Tested with the mbio eda local backend and front end one the initial-apps-run-update branch. Both ranked abundance and alpha div work as expected.

<img width="1127" alt="Screen Shot 2022-03-18 at 5 30 15 PM" src="https://user-images.githubusercontent.com/11710234/159085757-17d2a00d-cdcd-4bcd-8b6b-259a596f10f6.png">

<img width="1097" alt="Screen Shot 2022-03-18 at 5 29 46 PM" src="https://user-images.githubusercontent.com/11710234/159085777-bed47ba1-6125-460b-ba29-cfa596ad9a83.png">

Also tested with clinepi backend and main web-eda branch to make sure the whole site didn't crash. Visualizations look good.
