### PR TITLE
Purge APT cache after install in the same layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN useradd rserve \
 
 RUN apt-get update && apt-get install -y \
 	libglpk-dev \
-	libxml2-dev
+	libxml2-dev \
+	&& rm -rf /var/lib/apt/lists/*
 
 ## install libs
 ### Rserve


### PR DESCRIPTION
This is a minor improvement but will purge the APT cache after package installation before Docker caches the layer, reducing the image's overall size and the size of this particular layer.