### PR TITLE
Rationalise dependencies and pin versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,23 @@ RUN R -e "install.packages('readr')"
 RUN R -e "install.packages('digest')"
 RUN R -e "install.packages('Hmisc')"
 
-### Bioconductor
+# BioConductor - one still needed until microbiomeDB/microbiomeComputations@v5.1.6.x installs it automatically
+# see https://github.com/microbiomeDB/microbiomeComputations/issues/35
 RUN R -e "install.packages('BiocManager')"
-RUN R -e "BiocManager::install('SummarizedExperiment')"
-RUN R -e "BiocManager::install('DESeq2')"
 RUN R -e "BiocManager::install('Maaslin2')"
 
-RUN R -e "remotes::install_github('zdk123/SpiecEasi','v1.1.1', upgrade_dependencies=F)" 
+RUN R -e "remotes::install_github('VEuPathDB/plot.data', 'v5.6.0', dependencies=TRUE, upgrade_dependencies=FALSE)"
 
-RUN R -e "remotes::install_github('VEuPathDB/veupathUtils', 'v2.8.0', upgrade_dependencies=F)"
-RUN R -e "remotes::install_github('VEuPathDB/plot.data', 'v5.4.4', upgrade_dependencies=F)"
-RUN R -e "remotes::install_github('microbiomeDB/microbiomeComputations', 'v5.1.6', upgrade_dependencies=F)"
+# microbiomeDB/microbiomeComputations@v5.1.6 installs `VEuPathDB/veupathUtils` which in turn installs SpiecEasi@v1.0.7 (see below)
+#
+# Note that microbiomeDB/microbiomeComputations@v5.1.7 is a whole new ball game and installs mbioUtils.
+# mbioUtils shares too many functions with veupathUtils to import both - unless everything is fully qualified e.g. mbioUtils::some_function()
+#
+# plot.data@v5.6.0 also installs veupathUtils as a dependency which in turn installs
+# - SummarizedExperiment
+# - DESeq2
+# - zdk123/SpiecEasi@v1.0.
+RUN R -e "remotes::install_github('microbiomeDB/microbiomeComputations', 'v5.1.6', dependencies=TRUE, upgrade_dependencies=FALSE)"
 
 ## Rserve
 RUN mkdir -p /opt/rserve

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN useradd rserve \
 
 RUN apt-get update && apt-get install -y \
 	libglpk-dev \
-	libxml2-dev
+	libxml2-dev \
+	git
 
 ## install libs
 ### Rserve

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,23 +25,19 @@ RUN R -e "install.packages('readr')"
 RUN R -e "install.packages('digest')"
 RUN R -e "install.packages('Hmisc')"
 
-# BioConductor - one still needed until microbiomeDB/microbiomeComputations@v5.1.6.x installs it automatically
-# see https://github.com/microbiomeDB/microbiomeComputations/issues/35
-RUN R -e "install.packages('BiocManager')"
-RUN R -e "BiocManager::install('Maaslin2')"
+RUN R -e "remotes::install_github('VEuPathDB/plot.data', 'v5.6.1', dependencies=TRUE, upgrade_dependencies=FALSE)"
 
-RUN R -e "remotes::install_github('VEuPathDB/plot.data', 'v5.6.0', dependencies=TRUE, upgrade_dependencies=FALSE)"
-
-# microbiomeDB/microbiomeComputations@v5.1.6 installs `VEuPathDB/veupathUtils` which in turn installs SpiecEasi@v1.0.7 (see below)
+# microbiomeDB/microbiomeComputations@v5.1.6.2 installs Maaslin2 and `VEuPathDB/veupathUtils@v2.9.0`
+# which in turn installs SpiecEasi@v1.0.7 and more (see below)
 #
 # Note that microbiomeDB/microbiomeComputations@v5.1.7 is a whole new ball game and installs mbioUtils.
 # mbioUtils shares too many functions with veupathUtils to import both - unless everything is fully qualified e.g. mbioUtils::some_function()
 #
-# plot.data@v5.6.0 also installs veupathUtils as a dependency which in turn installs
+# plot.data@v5.6.1 also installs veupathUtils@v2.9.0 as a dependency which in turn installs
 # - SummarizedExperiment
 # - DESeq2
 # - zdk123/SpiecEasi@v1.0.
-RUN R -e "remotes::install_github('microbiomeDB/microbiomeComputations', 'v5.1.6', dependencies=TRUE, upgrade_dependencies=FALSE)"
+RUN R -e "remotes::install_github('microbiomeDB/microbiomeComputations', 'v5.1.6.2', dependencies=TRUE, upgrade_dependencies=FALSE)"
 
 ## Rserve
 RUN mkdir -p /opt/rserve


### PR DESCRIPTION
Copied from Slack (formatting is toast):

---

Here's a summary of what I've been doing for the last day and a half with regards to rationalising R package dependencies:

Rserve

Rationalised the dependencies in the Rserve Dockerfile (PR #35).

Before: Dockerfile had installation steps for BioConductor and github R packages that were already dependencies of plot.data and microbiomeComputations . This seemed to be a belt-and-braces approach to make sure dependencies are installed, but it's a maintenance nightmare if you want to be sure the versions are what you think they are.

After: Dockerfile only installs direct dependencies. Dependencies (and their dependencies) install their own dependencies automatically. Even if they are from BioConductor or github.  The key was actually reading the docs (!) for remotes package and using the bioc:: prefix in the Remotes: section of the DESCRIPTION files (R's package metadata) of the dependencies. And adding  git to the system dependencies in the Rserve image (turns out remotes::install_github() needs it, rocker/r-ver base image didn't have it) - without which, nested dependencies weren't installing at all (which may be why we added all the up-front dependencies in this Dockerfile in the first place?)

The microbiomeDB/microbiomeComputations v5.1.6.2 tag is off a new branch v5.1.6-branch which keeps using VEuPathDB/veupathUtils instead of the forked microbiomeDB/mbioUtils which is what happens in v5.1.7 which hasn't ever been deployed to our Rserve container and will likely cause issues with veupathUtils and mbioUtils exporting many of the same functions.

TL;DR: The Dockerfile is now leaner and more maintainable.

I'll continue in a thread with any nuggets from the other repos I touched.